### PR TITLE
only current credit cards can be added

### DIFF
--- a/bangazon-client-facing/src/components/paymentType/PaymentTypeForm.js
+++ b/bangazon-client-facing/src/components/paymentType/PaymentTypeForm.js
@@ -18,6 +18,7 @@ class PaymentTypeForm extends Component {
     savePaymentForm = () => {
         const currentDate = new Date().toISOString().slice(0,10);
         console.log(currentDate, this.state.expDate < currentDate)
+        //if statement to check that credit card expiration date is not less than today's date
         if (this.state.expDate < currentDate) {
             window.alert("Expiration Date cannot have already passed. \nPlease enter a valid Expiration Date")
         } else {

--- a/bangazon-client-facing/src/components/paymentType/PaymentTypeForm.js
+++ b/bangazon-client-facing/src/components/paymentType/PaymentTypeForm.js
@@ -16,14 +16,21 @@ class PaymentTypeForm extends Component {
     }
 
     savePaymentForm = () => {
-        const newPaymentType = {
-            "merchant_name": this.state.merchantName,
-            "acct_number": this.state.accountNumber,
-            "expiration_date": this.state.expDate
+        const currentDate = new Date().toISOString().slice(0,10);
+        console.log(currentDate, this.state.expDate < currentDate)
+        if (this.state.expDate < currentDate) {
+            window.alert("Expiration Date cannot have already passed. \nPlease enter a valid Expiration Date")
+        } else {
+            const newPaymentType = {
+                "merchant_name": this.state.merchantName,
+                "acct_number": this.state.accountNumber,
+                "expiration_date": this.state.expDate
+            }
+
+            console.log(newPaymentType.expiration_date)
+            ApiManager.post("paymenttypes", newPaymentType)
+            .then(() => this.props.history.push('/'))
         }
-        console.log(newPaymentType.expiration_date)
-        ApiManager.post("paymenttypes", newPaymentType)
-        .then(() => this.props.history.push('/'))
     }
 
     render() {


### PR DESCRIPTION
# Description

REACT
Modified PaymentTypeForm.js to disallow dates that are prior to current date

Fixes # 26

# Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions
- navigate to your react repo
- `git fetch --all`
- `git checkout sh-valid-expiration-date`
- Try adding a credit card (under My Account --> Payment Options --> Add a Payment Type)
- Enter in Institution and card number
- Select an expiration date that is before today
- Verify that you get a popup message indicating that you need to select a date that has not already passed
- Select a valid date
- Verify that card is added by going to My Account --> Payment Options 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [X] I have added test instructions that prove my fix is effective or that my feature works