### PR TITLE
Sh restricted characters in product name description

### DIFF
--- a/bangazon-client-facing/src/components/product/SellProductForm.js
+++ b/bangazon-client-facing/src/components/product/SellProductForm.js
@@ -29,9 +29,9 @@ class SellProductForm extends Component {
 
     handleSubmit = event => {
         event.preventDefault()   
-        const format = /[`!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?~]/
+        const format = /[!@#$%^&*()]/
         if (format.test(this.state.name) || format.test(this.state.description)) {
-            window.alert("No special characters are allowed in the name or description")
+            window.alert("Special characters (!@#$%^&*()) are not allowed in the name or description")
         }else if(!event.target.checkValidity()){
             return alert('please fill out form properly')
         }else{

--- a/bangazon-client-facing/src/components/product/SellProductForm.js
+++ b/bangazon-client-facing/src/components/product/SellProductForm.js
@@ -29,7 +29,10 @@ class SellProductForm extends Component {
 
     handleSubmit = event => {
         event.preventDefault()   
-        if (!event.target.checkValidity()){
+        const format = /[`!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?~]/
+        if (format.test(this.state.name) || format.test(this.state.description)) {
+            window.alert("No special characters are allowed in the name or description")
+        }else if(!event.target.checkValidity()){
             return alert('please fill out form properly')
         }else{
             const newProduct = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
# Description

Prevents save on create when !@#$%^&*() is in the Name or Description

Fixes # 31

# Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions

Please describe the tests required to verify your changes. Provide instructions so PR Tester can check functionality. Please also list any relevant details for your tests

- `git fetch --all`
- `git checkout sh-restricted-characters-in-product-name-description`
- Try to add a product to sell that includes any of !@#$%^&*() in the name and/or description
- You should get a window alert saying that you can't use them in the name and/or description and it won't save the product

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works